### PR TITLE
refactor: base url and endpoints

### DIFF
--- a/src/main/kotlin/io/konobank/core/data/Endpoints.kt
+++ b/src/main/kotlin/io/konobank/core/data/Endpoints.kt
@@ -1,12 +1,12 @@
 package io.konobank.core.data
 
 // Base
-const val BASE_URL = "https://api.monobank.ua"
+internal const val BASE_URL = "https://api.monobank.ua/"
 
 // Public methods
-const val CURRENCY_INFO = "/bank/currency"
+internal const val CURRENCY_INFO = "bank/currency"
 
 // Private methods
-const val CLIENT_INFO = "/personal/client-info"
-const val SET_WEBHOOK = "/personal/webhook"
-const val STATEMENT_ITEMS = "/personal/statement"
+internal const val CLIENT_INFO = "personal/client-info"
+internal const val SET_WEBHOOK = "personal/webhook"
+internal const val STATEMENT_ITEMS = "personal/statement"


### PR DESCRIPTION
make endpoints `internal` to prevent them from using outside the library